### PR TITLE
Add Button component, clean up babel, update index.js files

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+	"presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
+    "@babel/preset-react": "^7.0.0",
     "@tulipjs/eslint-config": "^1.1.1",
     "babel-loader": "^8.0.1",
     "css-loader": "^1.0.0",
@@ -36,5 +37,9 @@
     "url-loader": "^1.1.1",
     "webpack": "^4.17.1",
     "webpack-cli": "^3.1.0"
+  },
+  "dependencies": {
+    "react": "^16.4.2",
+    "styled-components": "^3.4.5"
   }
 }

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const ButtonWrapper = styled.button`
+	border-radius: 8px;
+	color: #fff;
+	background: mediumvioletred;
+	padding: 8px 15px;
+	border: none;
+	outline: none;
+`;
+
+function Button(props) {
+	return <ButtonWrapper {...props}>{props.children}</ButtonWrapper>;
+}
+
+export default Button;

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -1,0 +1,26 @@
+# Button
+
+This component renders an HTML `<button>` and passes along all props. 
+
+## Example Usage
+
+```jsx
+import React from 'react';
+import { Button } from 'rinse-react';
+
+class MyClass extends React.Component {
+	buttonClick() {
+		console.log('Ack! You got me!');
+	}
+
+	render() {
+		return (
+			<section>
+				<Button onClick={this.buttonClick}>
+					Get me!
+				</Button>
+			</section>
+		)
+	}
+}
+```

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -1,0 +1,3 @@
+import Button from './Button';
+
+export default Button;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,1 @@
+export { default as Button } from './Button';

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,1 @@
-const testFunction = () => 1 + 1;
-
-export default testFunction;
+export * from './components';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,9 +9,6 @@ module.exports = {
 				exclude: /node_modules/,
 				use: {
 					loader: 'babel-loader',
-					options: {
-						presets: ['@babel/preset-env'],
-					},
 				},
 			},
 			{


### PR DESCRIPTION
## Changes

This PR adds the first component, a simple Button. The structure of the Button.js file is a new one for me, using the `function` syntax to create a function component. One thing to note is that I am not using the `.jsx` extension. React knows what it's rendering, I prefer the cleaner folder. In the folder is also a README with a somewhat detailed code example. In the future READMEs should have details on the props and whatnot they interact with.

The index.js files in the src and components folders are now set to export the components. `src` exports them all blindly, but `components` is an explicit export. This architecture is meant to be easy to scale later, and tools like [Generact ](https://github.com/diegohaz/generact) make it easy to duplicate this elaborate folder structure.

I also moved the babel config out from the webpack config to its own `.babelrc` after adding the React preset.

## What do

Fixes #3 